### PR TITLE
fix: 「〜7日」セクションの表記を「1週間以内」に統一(#12)

### DIFF
--- a/TaskSchedular.Tests/MarkdownRendererTests.cs
+++ b/TaskSchedular.Tests/MarkdownRendererTests.cs
@@ -325,7 +325,7 @@ public class MarkdownRendererTests {
         var result = MarkdownRenderer.Render(tasks, today, sourcePath);
 
         // Assert
-        Assert.Contains("## 今週中（〜7日）", result);
+        Assert.Contains("## 1週間以内（〜7日）", result);
         Assert.Contains("1週間後のタスク", result);
     }
 

--- a/TaskSchedular/MarkdownRenderer.cs
+++ b/TaskSchedular/MarkdownRenderer.cs
@@ -240,7 +240,7 @@ internal static class MarkdownRenderer
 
         _WriteSection(sb, "今すぐ（着手日/期限が今日以前）", now);
         _WriteSection(sb, "次にやる（〜2日）", next2);
-        _WriteSection(sb, "今週中（〜7日）", week);
+        _WriteSection(sb, "1週間以内（〜7日）", week);
 
         var quick = ranked.Where(t => t.Estimate is { } e && e <= TimeSpan.FromMinutes(30)).ToList();
         _WriteSection(sb, "30分以内で終わる系", quick, dedupe: true);

--- a/TaskSchedular/Runner.cs
+++ b/TaskSchedular/Runner.cs
@@ -323,7 +323,7 @@ internal static class Runner
     /// <param name="today">現在の日付を基準とする比較日。</param>
     /// <returns>
     ///     タスクの優先度を示すセクションラベル文字列を返します。
-    ///     有効開始日や期限により「今すぐ」「次にやる」「今週中」「余裕があれば」に分類されます。
+    ///     有効開始日や期限により「今すぐ」「次にやる」「1週間以内」「余裕があれば」に分類されます。
     /// </returns>
     private static string _GetSectionLabel(TaskItem t, DateTime today)
     {
@@ -331,7 +331,7 @@ internal static class Runner
         if (effective is null) return "余裕があれば";
         if (effective <= today) return "今すぐ";
         if (effective <= today.AddDays(2)) return "次にやる";
-        if (effective <= today.AddDays(7)) return "今週中";
+        if (effective <= today.AddDays(7)) return "1週間以内";
 
         return "余裕があれば";
     }


### PR DESCRIPTION
「今週中（〜7日）」はカレンダー週の意味に誤解されうるため、実際の仕様である「7日以内」を明確化